### PR TITLE
Improve packet-layer buffering and parsing logic

### DIFF
--- a/utils/networking_test.go
+++ b/utils/networking_test.go
@@ -1,171 +1,105 @@
 package utils
 
-import "testing"
-import "net"
-import "time"
+import (
+	"bytes"
+	"io"
+	"testing"
+	"testing/iotest"
+)
 
-type MockConn struct {
-	Written    []byte
-	MockOutput []byte
+// Valid packets and their encoded forms
+var packetTests = []struct {
+	packet  RicochetData
+	encoded []byte
+}{
+	{RicochetData{1, []byte{}}, []byte{0x00, 0x04, 0x00, 0x01}},
+	{RicochetData{65535, []byte{0xDE, 0xAD, 0xBE, 0xEF}}, []byte{0x00, 0x08, 0xFF, 0xFF, 0xDE, 0xAD, 0xBE, 0xEF}},
+	{RicochetData{2, make([]byte, 65531)}, append([]byte{0xFF, 0xFF, 0x00, 0x02}, make([]byte, 65531)...)},
 }
 
-func (mc *MockConn) Read(b []byte) (int, error) {
-	copy(b[:], mc.MockOutput[:])
-	return len(mc.MockOutput), nil
-}
-
-func (mc *MockConn) Write(written []byte) (int, error) {
-	mc.Written = written
-	return 0, nil
-}
-
-func (mc *MockConn) LocalAddr() net.Addr {
-	return nil
-}
-
-func (mc *MockConn) RemoteAddr() net.Addr {
-	return nil
-}
-
-func (mc *MockConn) Close() error {
-	return nil
-}
-
-func (mc *MockConn) SetDeadline(t time.Time) error {
-	return nil
-}
-
-func (mc *MockConn) SetReadDeadline(t time.Time) error {
-	return nil
-}
-
-func (mc *MockConn) SetWriteDeadline(t time.Time) error {
-	return nil
-}
-
-func TestSentRicochetPacket(t *testing.T) {
-	conn := new(MockConn)
+// Test sending valid packets
+func TestSendRicochetPacket(t *testing.T) {
 	rni := RicochetNetwork{}
-	rni.SendRicochetPacket(conn, 1, []byte{})
-	if len(conn.Written) != 4 && conn.Written[0] != 0x00 && conn.Written[1] != 0x00 && conn.Written[2] != 0x01 && conn.Written[3] != 0x00 {
-		t.Errorf("Output of SentRicochetPacket was Unexpected: %x", conn.Written)
+	for _, td := range packetTests {
+		var buf bytes.Buffer
+		err := rni.SendRicochetPacket(&buf, td.packet.Channel, td.packet.Data)
+		if err != nil {
+			t.Errorf("Error sending packet %v: %v", td.packet, err)
+		} else if !bytes.Equal(buf.Bytes(), td.encoded) {
+			t.Errorf("Expected serialized packet %x but got %x", td.encoded, buf.Bytes())
+		}
 	}
 }
 
-func TestRecv(t *testing.T) {
-	conn := new(MockConn)
-	conn.MockOutput = []byte{0xDE, 0xAD, 0xBE, 0xEF}
+// Test sending invalid packets
+func TestSendRicochetPacket_Invalid(t *testing.T) {
 	rni := RicochetNetwork{}
-	buf, err := rni.Recv(conn)
-	if err != nil || len(buf) != 4 || buf[0] != 0xDE || buf[1] != 0xAD || buf[2] != 0xBE || buf[3] != 0xEF {
-		t.Errorf("Output of Recv was Unexpected: %x", buf)
+	invalidPackets := []RicochetData{
+		RicochetData{-1, []byte{}},
+		RicochetData{65536, []byte{}},
+		RicochetData{0, make([]byte, 65532)},
+	}
+
+	for _, td := range invalidPackets {
+		var buf bytes.Buffer
+		err := rni.SendRicochetPacket(&buf, td.Channel, td.Data)
+		// Expect error
+		if err == nil {
+			t.Errorf("Expected error when sending invalid packet %v", td)
+		}
 	}
 }
 
+// Test receiving valid packets
 func TestRecvRicochetPacket(t *testing.T) {
-	conn := new(MockConn)
-	conn.MockOutput = []byte{00, 0x04, 0x00, 0x01}
+	var buf bytes.Buffer
+	for _, td := range packetTests {
+		if _, err := buf.Write(td.encoded); err != nil {
+			t.Error(err)
+			return
+		}
+	}
 
+	// Use a HalfReader to test behavior on short socket reads also
+	reader := iotest.HalfReader(&buf)
 	rni := RicochetNetwork{}
-	rp, err := rni.RecvRicochetPackets(conn)
 
-	if err != nil {
-		t.Errorf("error extracting ricochet packets: %v", err)
-		return
-	}
-
-	if len(rp) != 1 {
-		t.Errorf("unexpected number of ricochet packets: %d", len(rp))
-	} else {
-		if rp[0].Channel != 1 {
-			t.Errorf("channel number is Unexpected expected 1: %d", rp[0].Channel)
-		}
-
-		if len(rp[0].Data) != 0 {
-			t.Errorf("expected emptry packet, instead got %x", rp[0].Data)
+	for _, td := range packetTests {
+		packet, err := rni.RecvRicochetPacket(reader)
+		if err != nil {
+			t.Errorf("Error receiving packet %v: %v", td.packet, err)
+			return
+		} else if !packet.Equals(td.packet) {
+			t.Errorf("Expected unserialized packet %v but got %v", td.packet, packet)
 		}
 	}
 
+	if packet, err := rni.RecvRicochetPacket(reader); err != io.EOF {
+		if err != nil {
+			t.Errorf("Expected EOF on packet stream but received error: %v", err)
+		} else {
+			t.Errorf("Expected EOF but received packet: %v", packet)
+		}
+	}
 }
 
-func TestRecvRicochetPacketInvalid(t *testing.T) {
-	conn := new(MockConn)
-	conn.MockOutput = []byte{00, 0x01, 0x00, 0x01}
-
+// Test receiving invalid packets
+func TestRecvRicochetPacket_Invalid(t *testing.T) {
 	rni := RicochetNetwork{}
-	_, err := rni.RecvRicochetPackets(conn)
-
-	if err == nil {
-		t.Errorf("recv should have errored due to invalid packets %v", err)
+	invalidPackets := [][]byte{
+		[]byte{0x00, 0x00, 0x00, 0x00},
+		[]byte{0x00, 0x03, 0x00, 0x00},
+		[]byte{0xff},
+		[]byte{0x00, 0x06, 0x00, 0x00, 0x00},
+		[]byte{},
 	}
 
-	conn.MockOutput = []byte{00, 0x0A, 0x00, 0x01}
-
-	_, err = rni.RecvRicochetPackets(conn)
-
-	if err == nil {
-		t.Errorf("recv should have errored due to invalid packets %v", err)
-	}
-
-}
-
-func TestRecvRicochetPacketLong(t *testing.T) {
-	conn := new(MockConn)
-	conn.MockOutput = []byte{0x00, 0x08, 0x00, 0xFF, 0xDE, 0xAD, 0xBE, 0xEF}
-
-	rni := RicochetNetwork{}
-	rp, err := rni.RecvRicochetPackets(conn)
-
-	if err != nil {
-		t.Errorf("error extracting ricochet packets: %v", err)
-		return
-	}
-
-	if len(rp) != 1 {
-		t.Errorf("unexpected number of ricochet packets: %d", len(rp))
-	} else {
-		if rp[0].Channel != 255 {
-			t.Errorf("channel number is Unexpected expected 255 got: %d", rp[0].Channel)
-		}
-
-		if len(rp[0].Data) != 4 || rp[0].Data[0] != 0xDE || rp[0].Data[1] != 0xAD || rp[0].Data[2] != 0xBE || rp[0].Data[3] != 0xEF {
-			t.Errorf("expected 0xDEADBEEF packet, instead got %x", rp[0].Data)
+	for _, td := range invalidPackets {
+		buf := bytes.NewBuffer(td)
+		packet, err := rni.RecvRicochetPacket(buf)
+		// Expect error
+		if err == nil {
+			t.Errorf("Expected error when sending invalid packet %x, got packet %v", td, packet)
 		}
 	}
-
-}
-
-func TestRecvRicochetPacketMultiplex(t *testing.T) {
-	conn := new(MockConn)
-	conn.MockOutput = []byte{0x00, 0x04, 0x00, 0x01, 0x00, 0x08, 0x00, 0xFF, 0xDE, 0xAD, 0xBE, 0xEF}
-
-	rni := RicochetNetwork{}
-	rp, err := rni.RecvRicochetPackets(conn)
-
-	if err != nil {
-		t.Errorf("error extracting ricochet packets: %v", err)
-		return
-	}
-
-	if len(rp) != 2 {
-		t.Errorf("unexpected number of ricochet packets, expected 2 gt: %d", len(rp))
-	} else {
-
-		if rp[0].Channel != 1 {
-			t.Errorf("channel number is Unexpected expected 1: %d", rp[0].Channel)
-		}
-
-		if len(rp[0].Data) != 0 {
-			t.Errorf("expected empty packet, instead got %x", rp[0].Data)
-		}
-
-		if rp[1].Channel != 255 {
-			t.Errorf("channel number is Unexpected expected 255 got: %d", rp[0].Channel)
-		}
-
-		if len(rp[1].Data) != 4 || rp[1].Data[0] != 0xDE || rp[1].Data[1] != 0xAD || rp[1].Data[2] != 0xBE || rp[1].Data[3] != 0xEF {
-			t.Errorf("expected 0xDEADBEEF packet, instead got %x", rp[0].Data)
-		}
-	}
-
 }


### PR DESCRIPTION
SendRicochetPacket now has error handling, correctly encodes channel
ids, accepts any io.Writer, and ensures that all data is written. All
callers should be changed at some point to handle errors also.

RecvRicochetPackets is refactored to return only one packet per call and
avoid reading more data than it will consume, which simplifies the logic
and fixes a number of problems with short reads or large packets. Also
fixed an error in bounds checking that caused a remote panic for invalid
packet sizes. It also now accepts any io.Reader.

Tests are updated and expanded, and now pass.

Changes to Ricochet.processConnection are whitespace-only, because of
the removal of the inner packets loop.