### PR TITLE
Make it possible to request stop of message loop

### DIFF
--- a/ricochet.go
+++ b/ricochet.go
@@ -93,8 +93,17 @@ func (r *Ricochet) processNewConnection(conn net.Conn, service RicochetService) 
 func (r *Ricochet) ProcessMessages(service RicochetService) {
 	for {
 		oc := <-r.newconns
+		if oc == nil {
+			return
+		}
 		go r.processConnection(oc, service)
 	}
+}
+
+// Request that the ProcessMessages loop is stopped after handling all currently
+// queued new connections.
+func (r *Ricochet) RequestStopMessageLoop() {
+	r.newconns <- nil
 }
 
 // ProcessConnection starts a blocking process loop which continually waits for

--- a/utils/networkresolver.go
+++ b/utils/networkresolver.go
@@ -40,7 +40,7 @@ func (nr *NetworkResolver) Resolve(hostname string) (net.Conn, string, error) {
 
 	torDialer, err := proxy.SOCKS5("tcp", "127.0.0.1:9050", nil, proxy.Direct)
 	if err != nil {
-		return nil,"", err
+		return nil, "", err
 	}
 
 	conn, err := torDialer.Dial("tcp", resolvedHostname+".onion:9878")


### PR DESCRIPTION
Add a `RequestStopMessageLoop()` method to `Ricochet` to be able to stop handling new connections. Right now, ProcessMessages is an infinite loop.

Intended to make it possible to fix the issue in https://github.com/s-rah/onionscan/pull/89.