### PR TITLE
Improve RequestOpenChannel API

### DIFF
--- a/channels/channel.go
+++ b/channels/channel.go
@@ -10,13 +10,6 @@ const (
 	Outbound
 )
 
-// AuthChannelResult captures the result of an authentication flow
-type AuthChannelResult struct {
-	Hostname       string
-	Accepted       bool
-	IsKnownContact bool
-}
-
 // Channel holds the state of a channel on an open connection
 type Channel struct {
 	ID int32

--- a/connection/autoconnectionhandler_test.go
+++ b/connection/autoconnectionhandler_test.go
@@ -2,6 +2,7 @@ package connection
 
 import (
 	"github.com/golang/protobuf/proto"
+	"github.com/s-rah/go-ricochet/channels"
 	"github.com/s-rah/go-ricochet/utils"
 	"github.com/s-rah/go-ricochet/wire/control"
 	"testing"
@@ -10,9 +11,10 @@ import (
 // Test sending valid packets
 func TestInit(t *testing.T) {
 	ach := new(AutoConnectionHandler)
-	privateKey, err := utils.LoadPrivateKeyFromFile("../testing/private_key")
-
-	ach.Init(privateKey, "")
+	ach.Init()
+	ach.RegisterChannelHandler("im.ricochet.auth.hidden-service", func() channels.Handler {
+		return &channels.HiddenServiceAuthChannel{}
+	})
 
 	// Construct the Open Authentication Channel Message
 	messageBuilder := new(utils.MessageBuilder)

--- a/connection/connection.go
+++ b/connection/connection.go
@@ -109,9 +109,10 @@ func (rc *Connection) Do(do func() error) error {
 // An error is returned only if the requirements for opening this channel
 // are not met on the local side (a nil error return does not mean the
 // channel was opened successfully, because channels open asynchronously).
-func (rc *Connection) RequestOpenChannel(ctype string, handler channels.Handler) error {
+func (rc *Connection) RequestOpenChannel(ctype string, handler channels.Handler) (*channels.Channel, error) {
 	rc.traceLog(fmt.Sprintf("requesting open channel of type %s", ctype))
-	return rc.Do(func() error {
+	var channel *channels.Channel
+	err := rc.Do(func() error {
 		// Check that we have the authentication already
 		if handler.RequiresAuthentication() != "none" {
 			// Enforce Authentication Check.
@@ -121,7 +122,8 @@ func (rc *Connection) RequestOpenChannel(ctype string, handler channels.Handler)
 			}
 		}
 
-		channel, err := rc.channelManager.OpenChannelRequest(handler)
+		var err error
+		channel, err = rc.channelManager.OpenChannelRequest(handler)
 
 		if err != nil {
 			rc.traceLog(fmt.Sprintf("failed to request open channel of type %v", err))
@@ -148,6 +150,7 @@ func (rc *Connection) RequestOpenChannel(ctype string, handler channels.Handler)
 		}
 		return nil
 	})
+	return channel, err
 }
 
 // Process receives socket and protocol events for the connection. Methods

--- a/connection/outboundconnectionhandler.go
+++ b/connection/outboundconnectionhandler.go
@@ -48,7 +48,7 @@ func (och *OutboundConnectionHandler) ProcessAuthAsClient(privateKey *rsa.Privat
 		och.connection.Break()
 	}
 
-	err := och.connection.RequestOpenChannel("im.ricochet.auth.hidden-service",
+	_, err := och.connection.RequestOpenChannel("im.ricochet.auth.hidden-service",
 		&channels.HiddenServiceAuthChannel{
 			PrivateKey:       privateKey,
 			ServerHostname:   och.connection.RemoteHostname,

--- a/examples/echobot/main.go
+++ b/examples/echobot/main.go
@@ -64,7 +64,7 @@ func (echobot *RicochetEchoBot) Connect(privateKeyFile string, hostname string) 
 		go rc.Process(echobot)
 
 		if !known {
-			err := rc.RequestOpenChannel("im.ricochet.contact.request", &channels.ContactRequestChannel{Handler: echobot})
+			_, err := rc.RequestOpenChannel("im.ricochet.contact.request", &channels.ContactRequestChannel{Handler: echobot})
 			if err != nil {
 				log.Printf("could not contact %s", err)
 			}

--- a/examples/echobot/main.go
+++ b/examples/echobot/main.go
@@ -45,7 +45,7 @@ func (echobot *RicochetEchoBot) Connect(privateKeyFile string, hostname string) 
 	privateKey, _ := utils.LoadPrivateKeyFromFile(privateKeyFile)
 	echobot.messages = make(chan string)
 
-	echobot.Init(privateKey, hostname)
+	echobot.Init()
 	echobot.RegisterChannelHandler("im.ricochet.contact.request", func() channels.Handler {
 		contact := new(channels.ContactRequestChannel)
 		contact.Handler = echobot
@@ -64,13 +64,13 @@ func (echobot *RicochetEchoBot) Connect(privateKeyFile string, hostname string) 
 		go rc.Process(echobot)
 
 		if !known {
-			err := rc.RequestOpenChannel("im.ricochet.contact.request", echobot)
+			err := rc.RequestOpenChannel("im.ricochet.contact.request", &channels.ContactRequestChannel{Handler: echobot})
 			if err != nil {
 				log.Printf("could not contact %s", err)
 			}
 		}
 
-		rc.RequestOpenChannel("im.ricochet.chat", echobot)
+		rc.RequestOpenChannel("im.ricochet.chat", &channels.ChatChannel{Handler: echobot})
 		for {
 			message := <-echobot.messages
 			log.Printf("Received Message: %s", message)


### PR DESCRIPTION
In the process of porting ricochet-go to these API changes, I ran into issues with RequestOpenChannel -- particularly that it expects a `connection.Handler` (which is used to get a channel handler) instead of `channels.Handler` directly. I think it makes much more sense to provide the handler for the new channel; see that commit for more details on why.

A related change was to disentangle HiddenServiceAuthChannel from AutoConnectionHandler. After the API change, there's not any need to put auth channel logic into the connection handler.

And finally, RequestOpenChannel is now returning the new Channel, which saves the lookup in many cases. That also solves a case where it would be ambiguous which channel you've just created if there are multiple instances of a channel type.

The individual commits have more details on my thinking here. Note that there are still some safety issues in {In,Out}boundConnectionHandler that these commits don't address -- see my other upcoming PRs. I've tested them all together more than separately.