### PR TITLE
Don't use pointers to interfaces

### DIFF
--- a/application/application.go
+++ b/application/application.go
@@ -51,7 +51,7 @@ func (rai *RicochetApplicationInstance) SendChatMessage(message string) {
 	rai.connection.Do(func() error {
 		channel := rai.connection.Channel("im.ricochet.chat", channels.Outbound)
 		if channel != nil {
-			chatchannel, ok := (*channel.Handler).(*channels.ChatChannel)
+			chatchannel, ok := channel.Handler.(*channels.ChatChannel)
 			if ok {
 				chatchannel.SendMessage(message)
 			}

--- a/channels/channel.go
+++ b/channels/channel.go
@@ -23,7 +23,7 @@ type Channel struct {
 
 	Type           string
 	Direction      Direction
-	Handler        *Handler
+	Handler        Handler
 	Pending        bool
 	ServerHostname string
 	ClientHostname string

--- a/connection/channelmanager.go
+++ b/connection/channelmanager.go
@@ -45,7 +45,7 @@ func (cm *ChannelManager) OpenChannelRequest(chandler channels.Handler) (*channe
 	channel.ID = cm.nextFreeChannel
 	cm.nextFreeChannel += 2
 	channel.Type = chandler.Type()
-	channel.Handler = &chandler
+	channel.Handler = chandler
 	channel.Pending = true
 	channel.Direction = channels.Outbound
 	cm.channels[channel.ID] = channel
@@ -76,7 +76,7 @@ func (cm *ChannelManager) OpenChannelRequestFromPeer(channelID int32, chandler c
 	channel := new(channels.Channel)
 	channel.ID = channelID
 	channel.Type = chandler.Type()
-	channel.Handler = &chandler
+	channel.Handler = chandler
 
 	channel.Pending = true
 	channel.Direction = channels.Inbound
@@ -90,7 +90,7 @@ func (cm *ChannelManager) OpenChannelRequestFromPeer(channelID int32, chandler c
 func (cm *ChannelManager) Channel(ctype string, way channels.Direction) *channels.Channel {
 	var foundChannel *channels.Channel
 	for _, channel := range cm.channels {
-		if (*channel.Handler).Type() == ctype && channel.Direction == way {
+		if channel.Handler.Type() == ctype && channel.Direction == way {
 			if foundChannel == nil {
 				foundChannel = channel
 			} else {

--- a/connection/connection.go
+++ b/connection/connection.go
@@ -203,11 +203,11 @@ func (rc *Connection) Process(handler Handler) error {
 				if len(packet.Data) == 0 {
 					rc.traceLog(fmt.Sprintf("removing channel %d", packet.Channel))
 					rc.channelManager.RemoveChannel(packet.Channel)
-					(*channel.Handler).Closed(utils.ChannelClosedByPeerError)
+					channel.Handler.Closed(utils.ChannelClosedByPeerError)
 				} else {
-					rc.traceLog(fmt.Sprintf("received packet on %v channel %d", (*channel.Handler).Type(), packet.Channel))
+					rc.traceLog(fmt.Sprintf("received packet on %v channel %d", channel.Handler.Type(), packet.Channel))
 					// Send The Ricochet Packet to the Handler
-					(*channel.Handler).Packet(packet.Data[:])
+					channel.Handler.Packet(packet.Data[:])
 				}
 			} else {
 				// When a non-zero packet is received for an unknown
@@ -297,10 +297,10 @@ func (rc *Connection) controlPacket(handler Handler, res *Protocol_Data_Control.
 
 		if cr.GetOpened() {
 			rc.traceLog(fmt.Sprintf("channel of type %v opened on %v", channel.Type, id))
-			(*channel.Handler).OpenOutboundResult(nil, cr)
+			channel.Handler.OpenOutboundResult(nil, cr)
 		} else {
 			rc.traceLog(fmt.Sprintf("channel of type %v rejected on %v", channel.Type, id))
-			(*channel.Handler).OpenOutboundResult(errors.New(""), cr)
+			channel.Handler.OpenOutboundResult(errors.New(""), cr)
 		}
 
 	} else if res.GetKeepAlive() != nil {

--- a/examples/echobot/main.go
+++ b/examples/echobot/main.go
@@ -79,7 +79,7 @@ func (echobot *RicochetEchoBot) Connect(privateKeyFile string, hostname string) 
 				channel := rc.Channel("im.ricochet.chat", channels.Outbound)
 				if channel != nil {
 					log.Printf("Found Chat Channel")
-					chatchannel, ok := (*channel.Handler).(*channels.ChatChannel)
+					chatchannel, ok := channel.Handler.(*channels.ChatChannel)
 					if ok {
 						chatchannel.SendMessage(message)
 					}


### PR DESCRIPTION
There are few situations where a pointer to an interface is useful in
Go, and this isn't one. Interfaces can hold types by value or pointer,
so long as that type fulfills the interface.