### PR TITLE
Improve ContactRequestChannel's API

### DIFF
--- a/application/acceptallcontactmanager.go
+++ b/application/acceptallcontactmanager.go
@@ -14,10 +14,6 @@ func (aacm *AcceptAllContactManager) LookupContact(hostname string, publicKey rs
 	return true, true
 }
 
-func (aacm *AcceptAllContactManager) GetContactDetails() (string, string) {
-	return "", ""
-}
-
 func (aacm *AcceptAllContactManager) ContactRequest(name string, message string) string {
 	return "Accepted"
 }

--- a/application/application.go
+++ b/application/application.go
@@ -28,10 +28,6 @@ type RicochetApplicationInstance struct {
 	ChatMessageAckHandler func(*RicochetApplicationInstance, uint32)
 }
 
-func (rai *RicochetApplicationInstance) GetContactDetails() (string, string) {
-	return "EchoBot", "I LIVE 😈😈!!!!"
-}
-
 func (rai *RicochetApplicationInstance) ContactRequest(name string, message string) string {
 	return "Accepted"
 }

--- a/channels/channel.go
+++ b/channels/channel.go
@@ -10,13 +10,6 @@ const (
 	Outbound
 )
 
-// AuthChannelResult captures the result of an authentication flow
-type AuthChannelResult struct {
-	Hostname       string
-	Accepted       bool
-	IsKnownContact bool
-}
-
 // Channel holds the state of a channel on an open connection
 type Channel struct {
 	ID int32

--- a/channels/contactrequestchannel_test.go
+++ b/channels/contactrequestchannel_test.go
@@ -12,10 +12,6 @@ type TestContactRequestHandler struct {
 	Received bool
 }
 
-func (tcrh *TestContactRequestHandler) GetContactDetails() (string, string) {
-	return "", ""
-}
-
 func (tcrh *TestContactRequestHandler) ContactRequest(name string, message string) string {
 	if name == "test_nickname" && message == "test_message" {
 		tcrh.Received = true
@@ -71,9 +67,11 @@ func TestContactRequestOpenOutbound(t *testing.T) {
 }
 
 func TestContactRequestOpenOutboundResult(t *testing.T) {
-	contactRequestChannel := new(ContactRequestChannel)
-	handler := new(TestContactRequestHandler)
-	contactRequestChannel.Handler = handler
+	contactRequestChannel := &ContactRequestChannel{
+		Name:    "test_nickname",
+		Message: "test_message",
+		Handler: &TestContactRequestHandler{},
+	}
 	channel := Channel{ID: 1}
 	contactRequestChannel.OpenOutbound(&channel)
 

--- a/connection/autoconnectionhandler_test.go
+++ b/connection/autoconnectionhandler_test.go
@@ -2,6 +2,7 @@ package connection
 
 import (
 	"github.com/golang/protobuf/proto"
+	"github.com/s-rah/go-ricochet/channels"
 	"github.com/s-rah/go-ricochet/utils"
 	"github.com/s-rah/go-ricochet/wire/control"
 	"testing"
@@ -10,9 +11,10 @@ import (
 // Test sending valid packets
 func TestInit(t *testing.T) {
 	ach := new(AutoConnectionHandler)
-	privateKey, err := utils.LoadPrivateKeyFromFile("../testing/private_key")
-
-	ach.Init(privateKey, "")
+	ach.Init()
+	ach.RegisterChannelHandler("im.ricochet.auth.hidden-service", func() channels.Handler {
+		return &channels.HiddenServiceAuthChannel{}
+	})
 
 	// Construct the Open Authentication Channel Message
 	messageBuilder := new(utils.MessageBuilder)

--- a/connection/connection.go
+++ b/connection/connection.go
@@ -109,9 +109,10 @@ func (rc *Connection) Do(do func() error) error {
 // An error is returned only if the requirements for opening this channel
 // are not met on the local side (a nil error return does not mean the
 // channel was opened successfully, because channels open asynchronously).
-func (rc *Connection) RequestOpenChannel(ctype string, handler channels.Handler) error {
+func (rc *Connection) RequestOpenChannel(ctype string, handler channels.Handler) (*channels.Channel, error) {
 	rc.traceLog(fmt.Sprintf("requesting open channel of type %s", ctype))
-	return rc.Do(func() error {
+	var channel *channels.Channel
+	err := rc.Do(func() error {
 		// Check that we have the authentication already
 		if handler.RequiresAuthentication() != "none" {
 			// Enforce Authentication Check.
@@ -121,7 +122,8 @@ func (rc *Connection) RequestOpenChannel(ctype string, handler channels.Handler)
 			}
 		}
 
-		channel, err := rc.channelManager.OpenChannelRequest(handler)
+		var err error
+		channel, err = rc.channelManager.OpenChannelRequest(handler)
 
 		if err != nil {
 			rc.traceLog(fmt.Sprintf("failed to request open channel of type %v", err))
@@ -148,6 +150,7 @@ func (rc *Connection) RequestOpenChannel(ctype string, handler channels.Handler)
 		}
 		return nil
 	})
+	return channel, err
 }
 
 // Process receives socket and protocol events for the connection. Methods

--- a/connection/outboundconnectionhandler.go
+++ b/connection/outboundconnectionhandler.go
@@ -48,7 +48,7 @@ func (och *OutboundConnectionHandler) ProcessAuthAsClient(privateKey *rsa.Privat
 		och.connection.Break()
 	}
 
-	err := och.connection.RequestOpenChannel("im.ricochet.auth.hidden-service",
+	_, err := och.connection.RequestOpenChannel("im.ricochet.auth.hidden-service",
 		&channels.HiddenServiceAuthChannel{
 			PrivateKey:       privateKey,
 			ServerHostname:   och.connection.RemoteHostname,

--- a/examples/echobot/main.go
+++ b/examples/echobot/main.go
@@ -64,7 +64,7 @@ func (echobot *RicochetEchoBot) Connect(privateKeyFile string, hostname string) 
 		go rc.Process(echobot)
 
 		if !known {
-			err := rc.RequestOpenChannel("im.ricochet.contact.request", &channels.ContactRequestChannel{Handler: echobot})
+			_, err := rc.RequestOpenChannel("im.ricochet.contact.request", &channels.ContactRequestChannel{Handler: echobot})
 			if err != nil {
 				log.Printf("could not contact %s", err)
 			}

--- a/examples/echobot/main.go
+++ b/examples/echobot/main.go
@@ -45,7 +45,7 @@ func (echobot *RicochetEchoBot) Connect(privateKeyFile string, hostname string) 
 	privateKey, _ := utils.LoadPrivateKeyFromFile(privateKeyFile)
 	echobot.messages = make(chan string)
 
-	echobot.Init(privateKey, hostname)
+	echobot.Init()
 	echobot.RegisterChannelHandler("im.ricochet.contact.request", func() channels.Handler {
 		contact := new(channels.ContactRequestChannel)
 		contact.Handler = echobot
@@ -64,13 +64,13 @@ func (echobot *RicochetEchoBot) Connect(privateKeyFile string, hostname string) 
 		go rc.Process(echobot)
 
 		if !known {
-			err := rc.RequestOpenChannel("im.ricochet.contact.request", echobot)
+			err := rc.RequestOpenChannel("im.ricochet.contact.request", &channels.ContactRequestChannel{Handler: echobot})
 			if err != nil {
 				log.Printf("could not contact %s", err)
 			}
 		}
 
-		rc.RequestOpenChannel("im.ricochet.chat", echobot)
+		rc.RequestOpenChannel("im.ricochet.chat", &channels.ChatChannel{Handler: echobot})
 		for {
 			message := <-echobot.messages
 			log.Printf("Received Message: %s", message)

--- a/examples/echobot/main.go
+++ b/examples/echobot/main.go
@@ -16,10 +16,6 @@ type RicochetEchoBot struct {
 	messages chan string
 }
 
-func (echobot *RicochetEchoBot) GetContactDetails() (string, string) {
-	return "EchoBot", "I LIVE 😈😈!!!!"
-}
-
 func (echobot *RicochetEchoBot) ContactRequest(name string, message string) string {
 	return "Pending"
 }
@@ -64,7 +60,12 @@ func (echobot *RicochetEchoBot) Connect(privateKeyFile string, hostname string) 
 		go rc.Process(echobot)
 
 		if !known {
-			_, err := rc.RequestOpenChannel("im.ricochet.contact.request", &channels.ContactRequestChannel{Handler: echobot})
+			_, err := rc.RequestOpenChannel("im.ricochet.contact.request",
+				&channels.ContactRequestChannel{
+					Handler: echobot,
+					Name:    "EchoBot",
+					Message: "I LIVE 😈😈!!!!",
+				})
 			if err != nil {
 				log.Printf("could not contact %s", err)
 			}


### PR DESCRIPTION
This is also based off of #28, so don't bother re-reviewing the first two commits of this branch.

After the RequestOpenChannel changes, it's now possible to specify the name and message of an outbound request as variables of the channel handler, instead implementing an interface method to return them.

Also added the SendResponse method, which is necessary to respond to an inbound request that was in the Pending state.