### PR TITLE
Improve ChatChannel API for message acknowledgement

### DIFF
--- a/application/application.go
+++ b/application/application.go
@@ -65,7 +65,7 @@ func (rai *RicochetApplicationInstance) ChatMessage(messageID uint32, when time.
 	return true
 }
 
-func (rai *RicochetApplicationInstance) ChatMessageAck(messageID uint32) {
+func (rai *RicochetApplicationInstance) ChatMessageAck(messageID uint32, accepted bool) {
 	rai.ChatMessageAckHandler(rai, messageID)
 }
 

--- a/channels/chatchannel_test.go
+++ b/channels/chatchannel_test.go
@@ -76,7 +76,7 @@ func (tcch *TestChatChannelHandler) ChatMessage(messageID uint32, when time.Time
 	return true
 }
 
-func (tcch *TestChatChannelHandler) ChatMessageAck(messageID uint32) {
+func (tcch *TestChatChannelHandler) ChatMessageAck(messageID uint32, accepted bool) {
 
 }
 
@@ -116,7 +116,7 @@ func TestChatChannelOperations(t *testing.T) {
 		t.Errorf("After Successful Result ChatChannel Is Still Pending")
 	}
 
-	chat := messageBuilder.ChatMessage("message text", 0)
+	chat := messageBuilder.ChatMessage("message text", 0, 0)
 	chatChannel.Packet(chat)
 
 	chatChannel.SendMessage("hello")

--- a/examples/echobot/main.go
+++ b/examples/echobot/main.go
@@ -36,7 +36,7 @@ func (echobot *RicochetEchoBot) ChatMessage(messageID uint32, when time.Time, me
 	return true
 }
 
-func (echobot *RicochetEchoBot) ChatMessageAck(messageID uint32) {
+func (echobot *RicochetEchoBot) ChatMessageAck(messageID uint32, accepted bool) {
 
 }
 

--- a/utils/messagebuilder.go
+++ b/utils/messagebuilder.go
@@ -195,10 +195,11 @@ func (mb *MessageBuilder) AuthResult(accepted bool, isKnownContact bool) []byte 
 }
 
 // ChatMessage constructs a chat message with the given content.
-func (mb *MessageBuilder) ChatMessage(message string, messageID uint32) []byte {
+func (mb *MessageBuilder) ChatMessage(message string, messageID uint32, timeDelta int64) []byte {
 	cm := &Protocol_Data_Chat.ChatMessage{
 		MessageId:   proto.Uint32(messageID),
 		MessageText: proto.String(message),
+		TimeDelta:   proto.Int64(timeDelta),
 	}
 	chatPacket := &Protocol_Data_Chat.Packet{
 		ChatMessage: cm,
@@ -209,10 +210,10 @@ func (mb *MessageBuilder) ChatMessage(message string, messageID uint32) []byte {
 }
 
 // AckChatMessage constructs a chat message acknowledgement.
-func (mb *MessageBuilder) AckChatMessage(messageID uint32) []byte {
+func (mb *MessageBuilder) AckChatMessage(messageID uint32, accepted bool) []byte {
 	cr := &Protocol_Data_Chat.ChatAcknowledge{
 		MessageId: proto.Uint32(messageID),
-		Accepted:  proto.Bool(true),
+		Accepted:  proto.Bool(accepted),
 	}
 	pc := &Protocol_Data_Chat.Packet{
 		ChatAcknowledge: cr,

--- a/utils/messagebuilder_test.go
+++ b/utils/messagebuilder_test.go
@@ -26,7 +26,7 @@ func TestOpenAuthenticationChannel(t *testing.T) {
 
 func TestChatMessage(t *testing.T) {
 	messageBuilder := new(MessageBuilder)
-	messageBuilder.ChatMessage("Hello World", 0)
+	messageBuilder.ChatMessage("Hello World", 0, 0)
 	// TODO: More Indepth Test Of Output
 }
 


### PR DESCRIPTION
ChatChannel didn't return the message ID for sent messages, which made
using the returned ACKs impossible. The SendMessage method now returns
the uin32 messageID.

Also, SendMessage didn't support the TimeDelta field for messages, which
is used for queued or resent messages. This is now available as
SendMessageWithTime.

And finally, the ChatMessageAck callback didn't indicate if mesasges
were accepted or not, which is part of the protocol. That was added as a
field, which is unfortunately a breaking API change, but I've made
enough of those lately to not feel guilty about it.